### PR TITLE
Implement Change Password Feature

### DIFF
--- a/app/Dto/ChangePasswordDto.php
+++ b/app/Dto/ChangePasswordDto.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Dto;
+
+use App\Dto\Contract\DtoContract;
+
+final readonly class ChangePasswordDto implements DtoContract
+{
+    public function __construct(
+        public string $currentPassword,
+        public string $newPassword
+    ) {}
+
+    public static function fromValidated(array $data): self
+    {
+        return new self(
+            $data['current_password'],
+            $data['new_password']
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'password' => $this->newPassword,
+        ];
+    }
+}

--- a/app/Http/Controllers/Password/PasswordController.php
+++ b/app/Http/Controllers/Password/PasswordController.php
@@ -51,10 +51,37 @@ class PasswordController extends Controller
 
         $this->passwordService->resetPassword(ResetPasswordDto::fromValidated($data));
 
-        self::logInfo('Password reset successfully for '.$data['email'], [
+        self::logInfo('Password reset successfully for ' . $data['email'], [
             'email' => $data['email'],
         ]);
 
         return ApiResponse::success(message: 'Password reset successfully.');
+    }
+
+    /**
+     * @throws PasswordServiceException
+     */
+    public function changePassword(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'current_password' => 'required|string',
+            'new_password' => 'required|string|min:8|confirmed',
+        ]);
+
+        self::logInfo('Password Data ', [
+            'data' => $data,
+        ]);
+        $user = $this->getLoggedInUser();
+        if (!$user) {
+            return ApiResponse::error(message: 'User is not authenticated.', status: 401);
+        }
+
+        $this->passwordService->changePassword($user["id"], $data['current_password'], $data['new_password']);
+
+        self::logInfo('Password changed successfully for ' . $user->email, [
+            'email' => $user->email,
+        ]);
+
+        return ApiResponse::success(message: 'Password changed successfully.');
     }
 }

--- a/app/Http/Controllers/Password/PasswordController.php
+++ b/app/Http/Controllers/Password/PasswordController.php
@@ -2,16 +2,19 @@
 
 namespace App\Http\Controllers\Password;
 
+use App\Dto\ChangePasswordDto;
 use App\Dto\ResetPasswordDto;
 use App\Exceptions\PasswordServiceException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ResetPasswordRequest;
+use App\Models\User;
 use App\Services\Contracts\PasswordServiceContract;
 use App\Utils\Response\ApiResponse;
 use App\Utils\Trait\HasAuthenticatedUser;
 use App\Utils\Trait\HasLogger;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
 
 class PasswordController extends Controller
 {
@@ -51,7 +54,7 @@ class PasswordController extends Controller
 
         $this->passwordService->resetPassword(ResetPasswordDto::fromValidated($data));
 
-        self::logInfo('Password reset successfully for ' . $data['email'], [
+        self::logInfo('Password reset successfully for '.$data['email'], [
             'email' => $data['email'],
         ]);
 
@@ -61,19 +64,21 @@ class PasswordController extends Controller
     /**
      * @throws PasswordServiceException
      */
-    public function changePassword(Request $request): JsonResponse
+    public function changePassword(Request $request, User $user): JsonResponse
     {
         $data = $request->validate([
-            'current_password' => 'required|string',
-            'new_password' => 'required|string|min:8|confirmed',
+            'current_password' => ['required'],
+            'new_password' => ['required', 'min:8', 'confirmed'],
         ]);
 
-        $this->passwordService->changePassword($user["id"], $data['current_password'], $data['new_password']);
+        $this->passwordService->changePassword(
+            ChangePasswordDto::fromValidated($data),
+            $user
+        );
 
-        self::logInfo('Password changed successfully for ' . $user->email, [
-            'email' => $user->email,
-        ]);
+        self::logInfo('Password changed successfully for');
 
-        return ApiResponse::success(message: 'Password changed successfully.');
+        return ApiResponse::success(message: 'Password changed successfully.')
+            ->withCookie(Cookie::forget('refresh_token'));
     }
 }

--- a/app/Http/Controllers/Password/PasswordController.php
+++ b/app/Http/Controllers/Password/PasswordController.php
@@ -68,14 +68,6 @@ class PasswordController extends Controller
             'new_password' => 'required|string|min:8|confirmed',
         ]);
 
-        self::logInfo('Password Data ', [
-            'data' => $data,
-        ]);
-        $user = $this->getLoggedInUser();
-        if (!$user) {
-            return ApiResponse::error(message: 'User is not authenticated.', status: 401);
-        }
-
         $this->passwordService->changePassword($user["id"], $data['current_password'], $data['new_password']);
 
         self::logInfo('Password changed successfully for ' . $user->email, [

--- a/app/Http/Requests/ResetPasswordRequest.php
+++ b/app/Http/Requests/ResetPasswordRequest.php
@@ -22,9 +22,9 @@ class ResetPasswordRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'password' => 'required|min:6|confirmed',
-            'email' => 'required|email|exists:password_reset_tokens,email',
-            'token' => 'required|string',
+            'password' => ['required', 'min:6', 'confirmed'],
+            'email' => ['required', 'email', 'exists:password_reset_tokens', 'email'],
+            'token' => ['required', 'string'],
 
         ];
     }

--- a/app/Services/Contracts/PasswordServiceContract.php
+++ b/app/Services/Contracts/PasswordServiceContract.php
@@ -16,4 +16,8 @@ interface PasswordServiceContract
      * @throws PasswordServiceException
      */
     public function resetPassword(ResetPasswordDto $dto): bool;
+    /**
+     * @throws PasswordServiceException
+     */
+    public function changePassword(int $userId, string $currentPassword, string $newPassword): bool;
 }

--- a/app/Services/Contracts/PasswordServiceContract.php
+++ b/app/Services/Contracts/PasswordServiceContract.php
@@ -2,8 +2,10 @@
 
 namespace App\Services\Contracts;
 
+use App\Dto\ChangePasswordDto;
 use App\Dto\ResetPasswordDto;
 use App\Exceptions\PasswordServiceException;
+use App\Models\User;
 
 interface PasswordServiceContract
 {
@@ -16,8 +18,9 @@ interface PasswordServiceContract
      * @throws PasswordServiceException
      */
     public function resetPassword(ResetPasswordDto $dto): bool;
+
     /**
      * @throws PasswordServiceException
      */
-    public function changePassword(int $userId, string $currentPassword, string $newPassword): bool;
+    public function changePassword(ChangePasswordDto $dto, User $attemptingUser): bool;
 }

--- a/app/Services/Password/PasswordService.php
+++ b/app/Services/Password/PasswordService.php
@@ -92,4 +92,31 @@ class PasswordService implements PasswordServiceContract
             throw new PasswordServiceException('Unable to reset the password');
         }
     }
+    public function changePassword(int $userId, string $currentPassword, string $newPassword): bool
+    {
+        try {
+            self::logInfo("Attempting to change the password for user ID {$userId}", [
+                'user_id' => $userId,
+            ]);
+
+            $user = User::query()->find($userId);
+
+            if (! $user || ! Hash::check($currentPassword, $user->password)) {
+                throw new PasswordServiceException('The current password is incorrect', code: Response::HTTP_UNPROCESSABLE_ENTITY);
+            }
+
+            $user->update([
+                'password' => Hash::make($newPassword),
+            ]);
+
+            return true;
+        } catch (Throwable $e) {
+            if ($e instanceof PasswordServiceException) {
+                throw $e;
+            }
+            self::logException($e, "Caught Exception when attempting to change the password for user ID {$userId}", ['user_id' => $userId]);
+
+            throw new PasswordServiceException('Unable to change the password');
+        }
+    }
 }

--- a/app/Services/Password/PasswordService.php
+++ b/app/Services/Password/PasswordService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Password;
 
+use App\Dto\ChangePasswordDto;
 use App\Dto\Mail\ForgetPasswordMailDto;
 use App\Dto\ResetPasswordDto;
 use App\Exceptions\PasswordServiceException;
@@ -92,29 +93,30 @@ class PasswordService implements PasswordServiceContract
             throw new PasswordServiceException('Unable to reset the password');
         }
     }
-    public function changePassword(int $userId, string $currentPassword, string $newPassword): bool
+
+    public function changePassword(ChangePasswordDto $dto, User $attemptingUser): bool
     {
         try {
-            self::logInfo("Attempting to change the password for user ID {$userId}", [
-                'user_id' => $userId,
-            ]);
+            self::logInfo('Attempting to change password');
 
-            $user = User::query()->find($userId);
-
-            if (! $user || ! Hash::check($currentPassword, $user->password)) {
-                throw new PasswordServiceException('The current password is incorrect', code: Response::HTTP_UNPROCESSABLE_ENTITY);
+            if ($attemptingUser->id !== self::getLoggedInUser()->id) {
+                throw new PasswordServiceException("you aren't authorized to perform this action", Response::HTTP_FORBIDDEN);
             }
 
-            $user->update([
-                'password' => Hash::make($newPassword),
-            ]);
+            if (! Hash::check($dto->currentPassword, $attemptingUser->password)) {
+                throw new PasswordServiceException('current Password doesn\'t match provided password', Response::HTTP_FORBIDDEN);
+            }
+
+            $attemptingUser->update($dto->toArray());
+            $attemptingUser->tokens()->delete();
+            $attemptingUser->refreshToken()->delete();
 
             return true;
         } catch (Throwable $e) {
             if ($e instanceof PasswordServiceException) {
                 throw $e;
             }
-            self::logException($e, "Caught Exception when attempting to change the password for user ID {$userId}", ['user_id' => $userId]);
+            self::logException($e, 'Caught Exception when attempting to change the password');
 
             throw new PasswordServiceException('Unable to change the password');
         }

--- a/routes/password/password-routes.php
+++ b/routes/password/password-routes.php
@@ -11,4 +11,7 @@ Route::group([
         ->middleware('throttle:3,10');
 
     Route::post('/reset/{email}/{token}', [PasswordController::class, 'resetPassword']);
+    Route::post('/change', [PasswordController::class, 'changePassword'])
+        ->middleware('auth:sanctum')
+        ->middleware('throttle:5,1');
 });

--- a/routes/password/password-routes.php
+++ b/routes/password/password-routes.php
@@ -11,7 +11,8 @@ Route::group([
         ->middleware('throttle:3,10');
 
     Route::post('/reset/{email}/{token}', [PasswordController::class, 'resetPassword']);
-    Route::post('/change', [PasswordController::class, 'changePassword'])
+
+    Route::patch('/change/{user}', [PasswordController::class, 'changePassword'])
         ->middleware('auth:sanctum')
-        ->middleware('throttle:3,10');
+        ->middleware('throttle:8,10');
 });

--- a/routes/password/password-routes.php
+++ b/routes/password/password-routes.php
@@ -13,5 +13,5 @@ Route::group([
     Route::post('/reset/{email}/{token}', [PasswordController::class, 'resetPassword']);
     Route::post('/change', [PasswordController::class, 'changePassword'])
         ->middleware('auth:sanctum')
-        ->middleware('throttle:5,1');
+        ->middleware('throttle:3,10');
 });

--- a/tests/Feature/Password/ChangePasswordTest.php
+++ b/tests/Feature/Password/ChangePasswordTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use Illuminate\Support\Facades\Hash;
+use Symfony\Component\HttpFoundation\Response;
+
+describe('Change Password', function (): void {
+    beforeEach(function (): void {
+        $this->oldPassword = TEST_USER_PASSWORD;
+        $this->newPassword = 'newPassword123';
+
+        $this->testUser = $this->salesRepUser;
+    });
+
+    it('allows authenticated user to change their password', function (): void {
+        $this->actingAs($this->testUser, 'sanctum');
+
+        $response = $this->patchJson('/api/password/change/'.$this->testUser->id, [
+            'current_password' => $this->oldPassword,
+            'new_password' => $this->newPassword,
+            'new_password_confirmation' => $this->newPassword,
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonStructure(['data', 'message']);
+
+        // Verify the password was actually changed
+        expect(Hash::check($this->newPassword, $this->testUser->fresh()->password))->toBeTrue()
+            ->and(Hash::check($this->oldPassword, $this->testUser->fresh()->password))->toBeFalse();
+    });
+
+    it('requires authentication to change password', function (): void {
+        $response = $this->patchJson('/api/password/change/'.$this->testUser->id, [
+            'current_password' => $this->oldPassword,
+            'new_password' => $this->newPassword,
+            'new_password_confirmation' => $this->newPassword,
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    });
+
+    it('validates current password is correct', function (): void {
+        $this->actingAs($this->testUser, 'sanctum');
+
+        $response = $this->patchJson('/api/password/change/'.$this->testUser->id, [
+            'current_password' => 'wrongPassword',
+            'new_password' => $this->newPassword,
+            'new_password_confirmation' => $this->newPassword,
+        ]);
+
+        $response->assertStatus(Response::HTTP_FORBIDDEN);
+
+        // Verify password wasn't changed
+        expect(Hash::check($this->oldPassword, $this->testUser->fresh()->password))->toBeTrue();
+    });
+
+    it('validates new password meets minimum requirements', function (): void {
+        $this->actingAs($this->testUser, 'sanctum');
+
+        $response = $this->patchJson('/api/password/change/'.$this->testUser->id, [
+            'current_password' => $this->oldPassword,
+            'new_password' => 'short',
+            'new_password_confirmation' => 'short',
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors(['new_password']);
+
+        // Verify password wasn't changed
+        expect(Hash::check($this->oldPassword, $this->testUser->fresh()->password))->toBeTrue();
+    });
+
+    it('validates new password confirmation matches', function (): void {
+        $this->actingAs($this->testUser, 'sanctum');
+
+        $response = $this->patchJson('/api/password/change/'.$this->testUser->id, [
+            'current_password' => $this->oldPassword,
+            'new_password' => $this->newPassword,
+            'new_password_confirmation' => 'differentPassword123',
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors(['new_password']);
+
+        // Verify password wasn't changed
+        expect(Hash::check($this->oldPassword, $this->testUser->fresh()->password))->toBeTrue();
+    });
+
+    it('requires current password field', function (): void {
+        $this->actingAs($this->testUser, 'sanctum');
+
+        $response = $this->patchJson('/api/password/change/'.$this->testUser->id, [
+            'new_password' => $this->newPassword,
+            'new_password_confirmation' => $this->newPassword,
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors(['current_password']);
+    });
+
+    it('requires new password field', function (): void {
+        $this->actingAs($this->testUser, 'sanctum');
+
+        $response = $this->patchJson('/api/password/change/'.$this->testUser->id, [
+            'current_password' => $this->oldPassword,
+            'new_password_confirmation' => $this->newPassword,
+        ]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors(['new_password']);
+    });
+});


### PR DESCRIPTION
This PR adds the Change Password functionality, allowing authenticated users to securely update their account passwords.

Key Updates:

Added changePassword method implement

- [x] ation in PasswordService to handle password validation and update.
- [x] Integrated controller endpoint for handling password change requests.
- [x] Added form validation for current_password, new_password, and confirm_password.
- [x] Improved error handling and success response structure via ApiResponse.
- [x] Ensured password update is restricted to authenticated users.

Testing Steps:

1. Send a POST request to /api/password/change with:
    - current_password
    - new_password
    - new_password_confirmation

2. Verify password is updated only if current password is correct.

3. Confirm appropriate error messages for invalid credentials or unauthenticated users.

Status: ✅ Ready for Review